### PR TITLE
Add tools for static checking & Gitlab CI processing of results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get -y install python3-setuptools
 RUN apt-get -y -t buster-backports install clang-8
 
 # Add tools for static checking & Gitlab CI processing of results
-RUN apt-get -y git python3-dev python3-pip clang-format-8 arcanist xmlstarlet php-codesniffer shellcheck
+RUN apt-get -y install git python3-dev python3-pip clang-format-8 arcanist xmlstarlet php-codesniffer shellcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/so
 
 RUN apt-get -y update
 
-# BCN build requriements
+# BCN build requirements
 RUN apt-get -y install python3 ccache bsdmainutils build-essential libssl-dev libevent-dev cmake libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb-dev libdb++-dev libminiupnpc-dev libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
 
 # Fetch ninja >= 1.10 to get the restat tool
@@ -38,3 +38,6 @@ RUN apt-get -y install python3-setuptools
 
 # Support clang build
 RUN apt-get -y -t buster-backports install clang-8
+
+# Add tools for static checking & Gitlab CI processing of results
+RUN apt-get -y git python3-dev python3-pip clang-format-8 arcanist xmlstarlet php-codesniffer shellcheck


### PR DESCRIPTION
Adding these tools to the build env would save time downloading and installing them in the Gitlab CI static_checks stage, ref. the https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/merge_requests/108