### PR TITLE
debian-v2: switch from clang-8 to clang-11 (for sanitizers)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 FROM debian:buster
 
-# Add backports for clang
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get -y update
+RUN apt-get -y install wget apt-utils gnupg
+
+# Add LLVM repos and key (for clang-11)
+RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main" >> /etc/apt/sources.list
+RUN echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main" >> /etc/apt/sources.list
+RUN wget --version
+RUN wget -O /etc/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+RUN apt-key add /etc/llvm-snapshot.gpg.key
 
 RUN apt-get -y update
 
@@ -43,10 +50,10 @@ RUN apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user-sta
 RUN apt-get -y install python3-setuptools
 
 # Support clang build
-RUN apt-get -y -t buster-backports install clang-8
+RUN apt-get -y install clang-11
 
 # Add tools for static checking & Gitlab CI processing of results
-RUN apt-get -y install git python3-dev python3-pip python3-scipy clang-format-8 arcanist xmlstarlet php-codesniffer shellcheck nodejs npm
+RUN apt-get -y install git python3-dev python3-pip python3-scipy clang-format-11 arcanist xmlstarlet php-codesniffer shellcheck nodejs npm
 RUN npm install npm@latest -g
 RUN npm install -g markdownlint-cli
 

--- a/build-container.sh
+++ b/build-container.sh
@@ -1,3 +1,3 @@
 set -e
-docker build --no-cache -t bitcoincashnode/buildenv:debian .
-docker push bitcoincashnode/buildenv:debian
+docker build --no-cache -t bitcoincashnode/buildenv:debian-v2 .
+docker push bitcoincashnode/buildenv:debian-v2


### PR DESCRIPTION
- remove buster-backports, it was only for clang-8 stuff
- install prerequisites `wget` and `gnupg` to obtain LLVM repo key
- add repo key and apt source for LLVM (to obtain clang-11)
- install `apt-utils` since docker build otherwise warned it deferred
  some steps due to absence of this package
- install clang-11
- remove clang-8
- update clang-format-8 to clang-format-11
  (we may decide to remove this at some other point when we completely
   remove arcanist config, until then it may still be useful)